### PR TITLE
Disable user selection for canvas while toggling labels

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -50,6 +50,10 @@ footer a {
     align-items: center;
 }
 
+canvas {
+  user-select: none;
+}
+
 .search-term {
     border: 1px solid rgba(0, 0, 0, 0.2);
     background: rgba(0, 0, 0, 0.025);


### PR DESCRIPTION
When you toggle the labels in the canvas quickly, the canvas gets selected. This pr fixes that.

#27 

![screenshot at dec 15 18-50-23](https://user-images.githubusercontent.com/5216601/34049672-5c3f8144-e1c9-11e7-919a-dc3e23b2e350.png)
