### PR TITLE
Reduce final Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 FROM maven:3.5.2-jdk-8-alpine as maven-build
-ENV TOKENS=""
 WORKDIR /app
 COPY . .
-RUN mvn install
-CMD java -Dapi-tokens=$TOKENS -jar target/github-profile-summary-1.0-jar-with-dependencies.jar
+RUN mvn verify
+
+FROM openjdk:8-jre-alpine
+RUN adduser \
+ -h /var/github-summary \
+ -D -u 1000 \
+ ghsum ghsum
+
+USER ghsum
+WORKDIR /var/github-summary
+
+ENV TOKENS=""
+ENTRYPOINT ["java", "-D token=${TOCKEN}", "-jar", "github-profile-summary.jar"]
+EXPOSE 7070
+
+COPY --from=maven-build \
+ --chown=ghsum:ghsum \
+ /app/target/github-profile-summary-jar-with-dependencies.jar github-profile-summary.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ USER ghsum
 WORKDIR /var/github-summary
 
 ENV TOKENS=""
-ENTRYPOINT ["java", "-D token=${TOCKEN}", "-jar", "github-profile-summary.jar"]
+ENTRYPOINT ["java", "-Dapi-tokens=${TOKENS}", "-jar", "github-profile-summary.jar"]
 EXPOSE 7070
 
 COPY --from=maven-build \

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     </dependencies>
 
     <build>
+      <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Using multi-stage dockerfile, so he end image doesn't have the source code, but only the binary of the project.

@tipsy you can build the image using `docker build -t tipsy/github-profile-summary .` and then `docker push tipsy/github-profile-summary` so that anyone can run your project with `docker run -p 7070:7070 --rm -ti tipsy/github-profile-summary`