### PR TITLE
Modernize date/time handling and Reduce cache lifetime to 6hrs

### DIFF
--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -24,7 +24,6 @@ object Cache {
         }
     }
 
-
     fun getUserProfile(username: String) = userProfiles[username.toLowerCase()]
     fun contains(username: String) = userProfiles[username.toLowerCase()] != null
     fun invalid(username: String): Boolean = userProfiles[username.toLowerCase()]?.timeStamp

--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -1,8 +1,8 @@
 package app
 
 import java.io.*
-import java.util.*
-import java.util.concurrent.TimeUnit
+import java.time.Duration
+import java.time.Instant
 
 object Cache {
 
@@ -25,7 +25,10 @@ object Cache {
 
     fun getUserProfile(username: String) = userProfiles[username.toLowerCase()]
     fun contains(username: String) = userProfiles[username.toLowerCase()] != null
-    fun invalid(username: String) = Date().time - (userProfiles[username.toLowerCase()]?.timeStamp ?: 0) > TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS)
+    fun invalid(username: String): Boolean = userProfiles[username.toLowerCase()]?.timeStamp
+            ?.let {
+                Duration.between(Instant.ofEpochMilli(it), Instant.now()).minusDays(1).nano > 0
+            } != false
 
     // Read cache from disk, return empty map if no cache file exists
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -8,7 +8,7 @@ object Cache {
 
     private const val path = "cache/userinfo"
     private val userProfiles = readUserProfilesFromDisk()
-    private val millisPerDay = TimeUnit.DAYS.toMillis(1)
+    private val millisCacheValid = TimeUnit.HOURS.toMillis(6)
 
     // Put userProfile in cache, then serialize cache and write it to disk
     fun putUserProfile(userProfile: UserProfile) {
@@ -28,7 +28,7 @@ object Cache {
     fun contains(username: String) = userProfiles[username.toLowerCase()] != null
     fun invalid(username: String): Boolean = userProfiles[username.toLowerCase()]?.timeStamp
             ?.let {
-                Instant.now().toEpochMilli() - it > millisPerDay
+                Instant.now().toEpochMilli() - it > millisCacheValid
             } != false
 
     // Read cache from disk, return empty map if no cache file exists

--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -1,13 +1,14 @@
 package app
 
 import java.io.*
-import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 object Cache {
 
     private const val path = "cache/userinfo"
     private val userProfiles = readUserProfilesFromDisk()
+    private val millisPerDay = TimeUnit.DAYS.toMillis(1)
 
     // Put userProfile in cache, then serialize cache and write it to disk
     fun putUserProfile(userProfile: UserProfile) {
@@ -23,11 +24,12 @@ object Cache {
         }
     }
 
+
     fun getUserProfile(username: String) = userProfiles[username.toLowerCase()]
     fun contains(username: String) = userProfiles[username.toLowerCase()] != null
     fun invalid(username: String): Boolean = userProfiles[username.toLowerCase()]?.timeStamp
             ?.let {
-                Duration.between(Instant.ofEpochMilli(it), Instant.now()).minusDays(1).nano > 0
+                Instant.now().toEpochMilli() - it > millisPerDay
             } != false
 
     // Read cache from disk, return empty map if no cache file exists

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -65,7 +65,7 @@ object UserCtrl {
     }
 
     private fun getYearAndQuarter(it: RepositoryCommit): String {
-        val date = LocalDateTime.ofInstant(it.commit.committer.date.toInstant(), ZoneOffset.UTC)
+        val date = it.commit.committer.date.toInstant().atOffset(ZoneOffset.UTC)
         return "${date.year}-Q${date.get(IsoFields.QUARTER_OF_YEAR)}"
     }
 

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -4,6 +4,7 @@ import org.eclipse.egit.github.core.Repository
 import org.eclipse.egit.github.core.RepositoryCommit
 import org.eclipse.egit.github.core.User
 import java.io.Serializable
+import java.time.Instant
 import java.util.*
 import kotlin.streams.toList
 
@@ -46,7 +47,7 @@ object UserCtrl {
             return true
         }
         if (GhService.remainingRequests == 0) {
-            return false;
+            return false
         }
         return try {
             GhService.watchers.pageWatched(username, 1, 100).first().map { it.name }.contains("github-profile-summary")
@@ -62,8 +63,9 @@ object UserCtrl {
     }
 
     private fun getYearAndQuarter(it: RepositoryCommit): String {
-        val date = it.commit.committer.date
-        return "${(1900 + date.year)}-Q${date.month / 3 + 1}"
+        val cal = Calendar.getInstance()
+        cal.time = it.commit.committer.date
+        return "${cal.get(Calendar.YEAR)}-Q${cal.get(Calendar.MONTH) / 3 + 1}"
     }
 
 }
@@ -79,5 +81,5 @@ data class UserProfile(
         val repoCommitCountDescriptions: Map<String, String?>,
         val repoStarCountDescriptions: Map<String, String?>
 ) : Serializable {
-    val timeStamp = Date().time
+    val timeStamp = Instant.now().toEpochMilli()
 }

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -5,7 +5,9 @@ import org.eclipse.egit.github.core.RepositoryCommit
 import org.eclipse.egit.github.core.User
 import java.io.Serializable
 import java.time.Instant
-import java.util.*
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.IsoFields
 import kotlin.streams.toList
 
 object UserCtrl {
@@ -63,9 +65,8 @@ object UserCtrl {
     }
 
     private fun getYearAndQuarter(it: RepositoryCommit): String {
-        val cal = Calendar.getInstance()
-        cal.time = it.commit.committer.date
-        return "${cal.get(Calendar.YEAR)}-Q${cal.get(Calendar.MONTH) / 3 + 1}"
+        val date = LocalDateTime.ofInstant(it.commit.committer.date.toInstant(), ZoneOffset.UTC)
+        return "${date.year}-Q${date.get(IsoFields.QUARTER_OF_YEAR)}"
     }
 
 }


### PR DESCRIPTION
* Avoid deprecated calls to the old api like [Date#getYear](https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#getYear--) and [Date#getMonth](https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#getMonth--)
* Replace [Date#getTime](https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#getTime--) with the more modern [Instant#now](https://docs.oracle.com/javase/8/docs/api/java/time/Instant.html#now--)
* Replace manual millisecond manipulation with the newer [Duration](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html) class when checking the validity of the cache
