### PR TITLE
Fix README for using GitHub tokens while running via Docker locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ You can enable Google Tag Manager on your instance by setting `gtm-id`:
 * `cd github-profile-summary`
 * `docker build -t github-profile-summary .`
 * `docker run -it --rm --name github-profile-summary -p 7070:7070 github-profile-summary`
-* OR with a token `docker run -it --rm --name github-profile-summary -p 7070:7070 -e "TOKENS=mytoken1,mytoken2" github-profile-summary`
+* OR with a token `docker run -it --rm --name github-profile-summary -p 7070:7070 -e "API_TOKENS=mytoken1,mytoken2" github-profile-summary`
 * browse to http://localhost:7070


### PR DESCRIPTION
Which has been written in https://github.com/tipsy/github-profile-summary/blob/0673ac0087ed96f7f7ff2afb19dd373e688fbc4b/src/main/kotlin/app/Config.kt#L11.

Should use "API_TOKENS" not "TOKENS".
  