### PR TITLE
Cache remainingRequests when updating sockets

### DIFF
--- a/src/main/kotlin/app/GhService.kt
+++ b/src/main/kotlin/app/GhService.kt
@@ -53,10 +53,10 @@ object GhService {
 
             // update all connected clients with remainingRequests twice per second
             scheduleAtFixedRate({
-                val payload = remainingRequests.toString()
+                val remainingRequests = remainingRequests.toString()
                 clientSessions.forEachKey(1) {
                     try {
-                        it.send(payload)
+                        it.send(remainingRequests)
                     } catch (e: Exception) {
                         log.error(e.toString())
                     }

--- a/src/main/kotlin/app/GhService.kt
+++ b/src/main/kotlin/app/GhService.kt
@@ -7,7 +7,6 @@ import org.eclipse.egit.github.core.service.RepositoryService
 import org.eclipse.egit.github.core.service.UserService
 import org.eclipse.egit.github.core.service.WatcherService
 import org.slf4j.LoggerFactory
-import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -54,9 +53,10 @@ object GhService {
 
             // update all connected clients with remainingRequests twice per second
             scheduleAtFixedRate({
+                val payload = remainingRequests.toString()
                 clientSessions.forEachKey(1) {
                     try {
-                        it.send(remainingRequests.toString())
+                        it.send(payload)
                     } catch (e: Exception) {
                         log.error(e.toString())
                     }


### PR DESCRIPTION
Avoids running the O(n) sum operation for every opened socket (i.e. O(n^2) -> O(n))