### PR TITLE
Color Refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.19</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0</version>
 
     <properties>
-        <kotlin.version>1.2.0</kotlin.version>
+        <kotlin.version>1.2.20</kotlin.version>
     </properties>
 
     <dependencies>
@@ -62,7 +62,7 @@
     </dependencies>
 
     <build>
-      <finalName>${project.artifactId}</finalName>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -31,12 +31,17 @@ object Cache {
 
     // Read cache from disk, return empty map if no cache file exists
     @Suppress("UNCHECKED_CAST")
-    private fun readUserProfilesFromDisk(): MutableMap<String, UserProfile> = if (File(path).exists()) {
-        ObjectInputStream(
-                ByteArrayInputStream(File("cache/userinfo").readBytes())
-        ).readObject() as MutableMap<String, UserProfile>
-    } else {
-        mutableMapOf()
+    private fun readUserProfilesFromDisk(): MutableMap<String, UserProfile> {
+        if (File(path).exists()) {
+            try {
+                return ObjectInputStream(
+                        ByteArrayInputStream(File("cache/userinfo").readBytes())
+                ).readObject() as MutableMap<String, UserProfile>
+            } catch (e: Exception) {
+            }
+        }
+
+        return mutableMapOf()
     }
 
 }

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -21,7 +21,7 @@ object UserCtrl {
             val langRepoCount = langRepoGrouping.eachCount().toList().sortedBy { (_, v) -> -v }.toMap()
             val langStarCount = langRepoGrouping.fold(0) { acc, repo -> acc + repo.watchers }.toList().sortedBy { (_, v) -> -v }.toMap()
             val langCommitCount = langRepoGrouping.fold(0) { acc, repo -> acc + repoCommits[repo]!!.size }.toList().sortedBy { (_, v) -> -v }.toMap()
-            val langColors = repos.associateBy({ it.language }, { GhService.getLangColor(it.language) })
+            val langColors = repos.filter({ it.language != null }).associateBy({ it.language }, { GhService.getLangColor(it.language) })
             val repoCommitCount = repoCommits.map { it.key.name to it.value.size }.toList().sortedBy { (_, v) -> -v }.take(10).toMap()
             val repoStarCount = repos.filter { it.watchers > 0 }.map { it.name to it.watchers }.sortedBy { (_, v) -> -v }.take(10).toMap()
 

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -21,6 +21,7 @@ object UserCtrl {
             val langRepoCount = langRepoGrouping.eachCount().toList().sortedBy { (_, v) -> -v }.toMap()
             val langStarCount = langRepoGrouping.fold(0) { acc, repo -> acc + repo.watchers }.toList().sortedBy { (_, v) -> -v }.toMap()
             val langCommitCount = langRepoGrouping.fold(0) { acc, repo -> acc + repoCommits[repo]!!.size }.toList().sortedBy { (_, v) -> -v }.toMap()
+            val langColors = repos.associateBy({ it.language }, { GhService.getLangColor(it.language) })
             val repoCommitCount = repoCommits.map { it.key.name to it.value.size }.toList().sortedBy { (_, v) -> -v }.take(10).toMap()
             val repoStarCount = repos.filter { it.watchers > 0 }.map { it.name to it.watchers }.sortedBy { (_, v) -> -v }.take(10).toMap()
 
@@ -33,6 +34,7 @@ object UserCtrl {
                     langRepoCount,
                     langStarCount,
                     langCommitCount,
+                    langColors,
                     repoCommitCount,
                     repoStarCount,
                     repoCommitCountDescriptions,
@@ -70,6 +72,7 @@ data class UserProfile(
         val langRepoCount: Map<String, Int>,
         val langStarCount: Map<String, Int>,
         val langCommitCount: Map<String, Int>,
+        val langColors: Map<String, String?>,
         val repoCommitCount: Map<String, Int>,
         val repoStarCount: Map<String, Int>,
         val repoCommitCountDescriptions: Map<String, String?>,

--- a/src/main/resources/static/charts.js
+++ b/src/main/resources/static/charts.js
@@ -78,18 +78,14 @@ function donutChart(objectName, data) {
     });
 
     function createColorArray(length) {
-        let array = [];
-        while (array.length < length) {
-            array = array.concat([
-                "#54ca76",
-                "#f5c452",
-                "#f2637f",
-                "#9261f3",
-                "#31a4e6",
-                "#55cbcb",
-            ]);
-        }
-        return array;
+        const colors = ["#54ca76", "#f5c452", "#f2637f", "#9261f3", "#31a4e6", "#55cbcb"];
+        let arr = Array.from(Array(length), (_, i) => colors[i % colors.length]);
+
+        // Edge case: avoid repetition where first and last colors are the same
+        if (length % colors.length === 1)
+            arr[length - 1] = colors[1];
+
+        return arr;
     }
 
     function arrayRotate(arr, n) {
@@ -152,4 +148,3 @@ function lineChart(objectName, data) {
         }
     });
 }
-

--- a/src/main/resources/static/charts.js
+++ b/src/main/resources/static/charts.js
@@ -8,10 +8,11 @@ function donutChart(objectName, data) {
     let values = Object.values(data[objectName]);
     let colors = createColorArray(labels.length);
     let tooltipInfo = null;
-    window.languageColors = window.languageColors || {};
+    window.languageColors = data["langColors"] || window.languageColors || {};
     if ("langRepoCount" === objectName) {
-        // when the first language-set is loaded, set a color-profile for all languages
-        labels.forEach((language, i) => languageColors[language] = colors[i]);
+        // when the first language-set is loaded, ensure a color-profile for all languages
+        labels.filter(lang => !languageColors[lang])
+            .forEach((language, i) => languageColors[language] = colors[i % colors.length]);
     }
     if (["langRepoCount", "langStarCount", "langCommitCount"].indexOf(objectName) > -1) {
         // if the dataset is language-related, load color-profile

--- a/src/main/resources/static/charts.js
+++ b/src/main/resources/static/charts.js
@@ -81,7 +81,7 @@ function donutChart(objectName, data) {
         const colors = ["#54ca76", "#f5c452", "#f2637f", "#9261f3", "#31a4e6", "#55cbcb"];
         let arr = Array.from(Array(length), (_, i) => colors[i % colors.length]);
 
-        // Edge case: avoid repetition where first and last colors are the same
+        // Edge case: avoid consecutive repetition where first and last colors are the same
         if (length % colors.length === 1)
             arr[length - 1] = colors[1];
 


### PR DESCRIPTION
Use Github's language colors in rendering charts pertaining to repo language

Notable minor changes:
* Bump kotlin version to latest stable
* Depend on snakeyaml for yaml parsing of github's language color definitions
* Don't allow createColorArray to end on the same color it began (provides some mitigation for #73 until more colors are identified)