### PR TITLE
fix path to jar-with-dependencies in instructions to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * `git clone https://github.com/tipsy/github-profile-summary.git`
 * `cd github-profile-summary`
 * `mvn install`
-* `java -jar target/github-profile-summary-1.0-jar-with-dependencies.jar`
+* `java -jar target/github-profile-summary-jar-with-dependencies.jar`
 
 If no api-token is set, you only get ~50 requests/hour
 
@@ -17,17 +17,17 @@ To run the app with an api-token, first generate a token at
 [https://github.com/settings/tokens](https://github.com/settings/tokens),
 then launch the jar with the token:
 
-* `java -Dapi-tokens=your-token -jar target/github-profile-summary-1.0-jar-with-dependencies.jar`
+* `java -Dapi-tokens=your-token -jar target/github-profile-summary-jar-with-dependencies.jar`
 
 You can use a comma-separated list of tokens to increase your rate-limit
 
 You can build a profile summary for any GitHub profile using `-Dunrestricted=true`:
 
-* `java -Dunrestricted=true -jar target/github-profile-summary-1.0-jar-with-dependencies.jar`
+* `java -Dunrestricted=true -jar target/github-profile-summary-jar-with-dependencies.jar`
 
 You can enable Google Tag Manager on your instance by setting `gtm-id`:
 
-* `java -Dgtm-id=GTM-XXXXXX -jar target/github-profile-summary-1.0-jar-with-dependencies.jar`
+* `java -Dgtm-id=GTM-XXXXXX -jar target/github-profile-summary-jar-with-dependencies.jar`
 
 ## run locally with docker
 


### PR DESCRIPTION
Instructions in the README erroneously mention the packaged jar file is at "target/github-profile-summary-1.0-jar-with-dependencies.jar" while it is actually "target/github-profile-summary-jar-with-dependencies.jar"